### PR TITLE
Add pygmab readme

### DIFF
--- a/pygmab/python/README.md
+++ b/pygmab/python/README.md
@@ -14,11 +14,11 @@ study, bounds = gmab.create_study(seed=42)
 
 ## 2. Define objective and bounds
 
-Rust-gmab uses a list of integers as action_vector, where a tuple (low. high) defines the bounds
-for each element of the action_vector. The action_vector is then used as single parameter to simulate
-with the objective function.
+The direct interface with rust uses a list of integers as action_vector, where a tuple `(low, high)`
+defines the bounds for each element of the action_vector. The action_vector is then used to
+simulate the objective.
 
-From examples/tester.py:
+From ./examples/tester.py:
 
 ```python
 from gmab import Gmab
@@ -38,8 +38,7 @@ if __name__ == "__main__":
 ```
 
 While this works well for an objective function with one integer decision vector, users likely
-expect a simple, and more interactive interface that enables setting bounds for multiple parameters,
-and with different types.
+expect an interactive interface that enables setting bounds for multiple parameters dynamically.
 
 Internally, this will require:
 
@@ -47,9 +46,9 @@ Internally, this will require:
 starting the optimization.
 * For each simulation, mapping the action_vector from rust to the kwargs of the objective.
 * For example, the value `1` in the action_vector will be mapped to `10` if the parameter is
-configured with bounds.suggest_int(low=0, high=100, steps=10).
+configured with `bounds.suggest_int(low=0, high=100, steps=10)`.
 * Alternatively, the value `1` in the action_vector will be mapped to `manhattan` if the
-parameter is configured with bounds.suggest_categorical(["euclidean", "manhattan", "canberra"])
+parameter is configured with `bounds.suggest_categorical(["euclidean", "manhattan", "canberra"])`.
 
 Below are two examples to illustrate how users will be able to define the objective and the
 params.
@@ -60,8 +59,8 @@ Compared to the rosenbrock function, a similar vector (list of numbers) is input
 if the net present value is calculated. The implementation below would enable the user to
 dynamically set bounds for cash_flows (in example: 3 periods, with 100 values between 0 and 100_000)
 
-In addition, an interest rate is also needed as input, which would be complicated to manage
-with an `objective(numbers: list)` type of function due to the different variable type and bounds.
+In addition, an interest rate is also needed as input. With an `objective(numbers: list)` type
+of function, the user would need to explicitly handle this in the objective function.
 
 ```python
 def objective(cash_flows: list, interest: float) -> float:
@@ -85,8 +84,8 @@ from sklearn.metrics import silhouette_score
 # Assume data is defined as x_train
 
 def objective(eps: float, min_samples:int, metric: str) -> float:
-    clusterer = DBSCAN(eps, min_samples, metric)
-    clusterer.fix(x_train)
+    clusterer = DBSCAN(eps=eps, min_samples=min_samples, metric=metric)
+    clusterer.fit(x_train)
     return silhouette_score(x_train, clusterer.labels_)
 
 params = {
@@ -100,9 +99,8 @@ params = {
 
 Use `study.optimize()` to start optimization with given settings.
 
-Internally, the method will need to store and transform the user inputs for rust-gmab,
-and then create and execute the set number of algorithm instances. Finally, it will also
-collect the results in a storage.
+Internally, the method will store and transform the user inputs for rust-gmab, and then create
+and execute the set number of algorithm instances. Finally, it will also collect the results.
 
 ```python
 study.optimize(objective, params, n_trials=5, n_simulations=10000, popsize=100, ...)

--- a/pygmab/python/README.md
+++ b/pygmab/python/README.md
@@ -58,7 +58,7 @@ params.
 Similar to the integer decision vector of the rosenbrock function, the calculation of the net present
 value requires a `cash_flows` vector.
 
-In addition, an interest rate is also needed to calcuate the NPV. With an `objective(numbers: list)`
+In addition, an interest rate is also needed to calculate the NPV. With an `objective(numbers: list)`
 type of function, the user would need to explicitly handle this in the objective function.
 
 ```python
@@ -66,8 +66,8 @@ def objective(cash_flows: list, interest: float) -> float:
     return sum([cf / (1 + interest) ** t for t, cf in enumerate(cash_flows)])
 
 params = {
-    "cash_flows": bounds.suggest_int(low=0, high=100000, steps=100, size=3),
-    "interest": bounds.suggest_float(low=0.0, high=0.1, steps=100)
+    "cash_flows": bounds.suggest_int(low=0, high=100000, step=100, size=3),
+    "interest": bounds.suggest_float(low=0.0, high=0.1, step=0.001)
 }
 ```
 
@@ -88,7 +88,7 @@ def objective(eps: float, min_samples:int, metric: str) -> float:
     return silhouette_score(x_train, clusterer.labels_)
 
 params = {
-    "eps": bounds.suggest_float(low=0.1, high=0.9, steps=10),
+    "eps": bounds.suggest_float(low=0.1, high=0.9, step=0.001),
     "min_samples": bounds.suggest_int(low=2, high=10),
     "metric": bounds.suggest_categorical(["euclidean", "manhattan", "canberra"]),
 }

--- a/pygmab/python/README.md
+++ b/pygmab/python/README.md
@@ -1,0 +1,89 @@
+# Vision for pygmab interface UI
+
+## 1. Create a Study
+Use create_study() to initialize an instance of Study, which is a class that handles algorithm
+control, and Bounds, which is a class that handles the algorithm's bounds and mapping of all parameters.
+
+```python
+import gmab
+
+study, bounds = gmab.create_study(seed=42)
+```
+
+## 2. Define objective and bounds
+Rust-gmab uses a list of integers as action_vector, where a tuple (low. high) defines the bounds
+for each element of the action_vector. The action_vector is then used as single parameter to simulate
+with the objective function.
+
+From examples/tester.py:
+
+```python
+def rosenbrock_function(number: list):
+    return sum(
+        [
+            100 * (number[i + 1] - number[i] ** 2) ** 2 + (1 - number[i]) ** 2
+            for i in range(len(number) - 1)
+        ]
+    )
+
+if __name__ == "__main__":
+    bounds = [(-5, 10), (-5, 10)]
+    gmab = Gmab(rosenbrock_function, bounds)
+```
+
+While this works well for an objective function with one integer decision vector, users likely
+expect a simple, and more interactive interface that enables setting bounds for multiple parameters,
+and with different types.
+
+Internally, this will require:
+    - Handling and checking the user's inputs to create the bounds tuple for rust-gmab before
+    starting the optimization.
+    - For each simulation, mapping the action_vector from rust to the kwargs of the objective.
+    - For example, the value `1` in the action_vector will be mapped to `10` if the parameter is
+    configured with bounds.suggest_int(low=0, high=100, steps=10).
+    - Alternatively, the value `1` in the action_vector will be mapped to `manhattan` if the
+    parameter is configured with bounds.suggest_categorical(["euclidean", "manhattan", "canberra"])
+
+Below are two examples that demonstrate how pygmab can be used.
+
+### Net present value example
+
+```python
+def objective(cash_flows: list, interest: float) -> float:
+    return sum([cf / (1 + interest) ** t for t, cf in enumerate(cash_flows)])
+
+params = {
+    "cash_flows": bounds.suggest_int(low=0, high=100000, steps=1000, size=3),
+    "interest": bounds.suggest_float(low=0.0, high=0.1, steps=100)
+}
+```
+
+### Clustering Example
+
+```python
+from sklearn.cluster import DBSCAN
+from sklearn.metrics import silhouette_score
+
+# Assume data is defined as x_train
+
+def objective(eps: float, min_samples:int, metric: str) -> float:
+    clusterer = DBSCAN(eps, min_samples, metric)
+    clusterer.fix(x_train)
+    return silhouette_score(x_train, clusterer.labels_)
+
+params = {
+    "eps": bounds.suggest_float(low=0.1, high=0.9, steps=10),
+    "min_samples": bounds.suggest_int(low=2, high=10),
+    "metric": bounds.suggest_categorical(["euclidean", "manhattan", "canberra"]),
+}
+```
+
+
+```python
+from gmab import Gmab
+
+```
+```python
+from gmab import Gmab
+
+```

--- a/pygmab/python/README.md
+++ b/pygmab/python/README.md
@@ -3,13 +3,13 @@ Suggestions how a user interface for pygmab can be implemented. Feel free to com
 
 ## 1. Create a Study
 
-Use create_study() to initialize an instance of `Study`, which is a class that handles algorithm
+Use `initialize()` to initialize instances of `Study`, which is a class that handles algorithm
 control, and `Bounds`, which is a class that handles the algorithm's bounds and mapping of all parameters.
 
 ```python
 import gmab
 
-study, bounds = gmab.create_study(seed=42)
+study, bounds = gmab.initialize(seed=42) # prev. gmab.create_study()
 ```
 
 ## 2. Define objective and bounds
@@ -42,9 +42,9 @@ expect an interface that enables dynamically setting bounds for multiple paramet
 
 Internally, this will require:
 
-* Handling and checking the user's inputs to create the bounds tuple for rust-gmab before
-starting the optimization.
-* For each simulation, mapping the action_vector from rust to the kwargs of the objective.
+* Handling and checking the user's inputs to create the `bounds` tuple that is expected by
+rust-gmab when starting the optimization.
+* For each simulation, mapping the action_vector generated in rust to the `kwargs` of the objective.
 * For example, the value `1` in the action_vector will be mapped to `10` if the parameter is
 configured with `bounds.suggest_int(low=0, high=100, steps=10)`.
 * Alternatively, the value `1` in the action_vector will be mapped to `manhattan` if the
@@ -55,7 +55,7 @@ params.
 
 ### Net present value example (just for illustration of the UI)
 
-Similar to integer decision vector of the rosenbrock function, the calculation of the net present
+Similar to the integer decision vector of the rosenbrock function, the calculation of the net present
 value requires a `cash_flows` vector.
 
 In addition, an interest rate is also needed to calcuate the NPV. With an `objective(numbers: list)`

--- a/pygmab/python/README.md
+++ b/pygmab/python/README.md
@@ -3,8 +3,8 @@ Suggestions how a user interface for pygmab can be implemented. Feel free to com
 
 ## 1. Create a Study
 
-Use create_study() to initialize an instance of Study, which is a class that handles algorithm
-control, and Bounds, which is a class that handles the algorithm's bounds and mapping of all parameters.
+Use create_study() to initialize an instance of `Study`, which is a class that handles algorithm
+control, and `Bounds`, which is a class that handles the algorithm's bounds and mapping of all parameters.
 
 ```python
 import gmab
@@ -18,7 +18,7 @@ The direct interface with rust uses a list of integers as action_vector, where a
 defines the bounds for each element of the action_vector. The action_vector is then used to
 simulate the objective.
 
-From ./examples/tester.py:
+From [./examples/tester.py](https://github.com/E-MAB/GMAB/blob/add-pygmab-readme/examples/tester.py)
 
 ```python
 from gmab import Gmab
@@ -37,8 +37,8 @@ if __name__ == "__main__":
     ...
 ```
 
-While this works well for an objective function with one integer decision vector, users likely
-expect an interactive interface that enables setting bounds for multiple parameters dynamically.
+While this works well for an objective function with one integer decision vector, users will
+expect an interface that enables dynamically setting bounds for multiple parameters and types.
 
 Internally, this will require:
 
@@ -53,14 +53,13 @@ parameter is configured with `bounds.suggest_categorical(["euclidean", "manhatta
 Below are two examples to illustrate how users will be able to define the objective and the
 params.
 
-### Net present value example (just for illustration of UI)
+### Net present value example (just for illustration of the UI)
 
-Compared to the rosenbrock function, a similar vector (list of numbers) is input as cash_flows
-if the net present value is calculated. The implementation below would enable the user to
-dynamically set bounds for cash_flows (in example: 3 periods, with 100 values between 0 and 100_000)
+Similar to integer decision vector of the rosenbrock function, the calculation of the net present
+value requires a `cash_flows` vector.
 
-In addition, an interest rate is also needed as input. With an `objective(numbers: list)` type
-of function, the user would need to explicitly handle this in the objective function.
+In addition, an interest rate is also needed to calcuate the NPV. With an `objective(numbers: list)`
+type of function, the user would need to explicitly handle this in the objective function.
 
 ```python
 def objective(cash_flows: list, interest: float) -> float:
@@ -99,6 +98,23 @@ params = {
 
 Use `study.optimize()` to start optimization with given settings.
 
+Names for settings are (somewhat) based on:
+
+* [optuna.study.Study](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study)
+* [optuna.samplers.NSGAIISampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.NSGAIISampler.html)
+
+
+| Name              | Description                                                             |
+|-------------------|-------------------------------------------------------------------------|
+| `max_time`        | Maximum execution time per algorithm instance                           |
+| `max_trials`      | Maximum number of simulations per algorithm instance                    |
+| `population_size` | Number of individuals (trials) in a generation                          |
+| `crossover_rate`  | Probability for a crossover (exchange of values between individuals)    |
+| `mutation_rate`   | Probability for a mutation (change to a value of an individual)         |
+| `mutation_span`   | Sets how much a value is altered during mutation                        |
+| `...`             | Other parameters to set verbose, parallelization, name, ...             |
+
+
 Internally, the method will store and transform the user inputs for rust-gmab, and then create
 and execute the set number of algorithm instances. Finally, it will also collect the results.
 
@@ -106,7 +122,7 @@ and execute the set number of algorithm instances. Finally, it will also collect
 study.optimize(objective, params, n_trials=5, n_simulations=10000, popsize=100, ...)
 ```
 
-## 4. Access the results (TBD.)
+## 4. Access the results (additional features TBD.)
 
 Use `study.best_trial()` to output the best result that has been returned.
 

--- a/pygmab/python/README.md
+++ b/pygmab/python/README.md
@@ -1,6 +1,8 @@
-# Vision for pygmab interface UI
+# Vision for pygmab interface
+Suggestions how a user interface for pygmab can be implemented. Feel free to comment!
 
 ## 1. Create a Study
+
 Use create_study() to initialize an instance of Study, which is a class that handles algorithm
 control, and Bounds, which is a class that handles the algorithm's bounds and mapping of all parameters.
 
@@ -11,6 +13,7 @@ study, bounds = gmab.create_study(seed=42)
 ```
 
 ## 2. Define objective and bounds
+
 Rust-gmab uses a list of integers as action_vector, where a tuple (low. high) defines the bounds
 for each element of the action_vector. The action_vector is then used as single parameter to simulate
 with the objective function.
@@ -18,6 +21,8 @@ with the objective function.
 From examples/tester.py:
 
 ```python
+from gmab import Gmab
+
 def rosenbrock_function(number: list):
     return sum(
         [
@@ -29,6 +34,7 @@ def rosenbrock_function(number: list):
 if __name__ == "__main__":
     bounds = [(-5, 10), (-5, 10)]
     gmab = Gmab(rosenbrock_function, bounds)
+    ...
 ```
 
 While this works well for an objective function with one integer decision vector, users likely
@@ -36,29 +42,41 @@ expect a simple, and more interactive interface that enables setting bounds for 
 and with different types.
 
 Internally, this will require:
-    - Handling and checking the user's inputs to create the bounds tuple for rust-gmab before
-    starting the optimization.
-    - For each simulation, mapping the action_vector from rust to the kwargs of the objective.
-    - For example, the value `1` in the action_vector will be mapped to `10` if the parameter is
-    configured with bounds.suggest_int(low=0, high=100, steps=10).
-    - Alternatively, the value `1` in the action_vector will be mapped to `manhattan` if the
-    parameter is configured with bounds.suggest_categorical(["euclidean", "manhattan", "canberra"])
 
-Below are two examples that demonstrate how pygmab can be used.
+* Handling and checking the user's inputs to create the bounds tuple for rust-gmab before
+starting the optimization.
+* For each simulation, mapping the action_vector from rust to the kwargs of the objective.
+* For example, the value `1` in the action_vector will be mapped to `10` if the parameter is
+configured with bounds.suggest_int(low=0, high=100, steps=10).
+* Alternatively, the value `1` in the action_vector will be mapped to `manhattan` if the
+parameter is configured with bounds.suggest_categorical(["euclidean", "manhattan", "canberra"])
 
-### Net present value example
+Below are two examples to illustrate how users will be able to define the objective and the
+params.
+
+### Net present value example (just for illustration of UI)
+
+Compared to the rosenbrock function, a similar vector (list of numbers) is input as cash_flows
+if the net present value is calculated. The implementation below would enable the user to
+dynamically set bounds for cash_flows (in example: 3 periods, with 100 values between 0 and 100_000)
+
+In addition, an interest rate is also needed as input, which would be complicated to manage
+with an `objective(numbers: list)` type of function due to the different variable type and bounds.
 
 ```python
 def objective(cash_flows: list, interest: float) -> float:
     return sum([cf / (1 + interest) ** t for t, cf in enumerate(cash_flows)])
 
 params = {
-    "cash_flows": bounds.suggest_int(low=0, high=100000, steps=1000, size=3),
+    "cash_flows": bounds.suggest_int(low=0, high=100000, steps=100, size=3),
     "interest": bounds.suggest_float(low=0.0, high=0.1, steps=100)
 }
 ```
 
 ### Clustering Example
+
+Compared to the rosenbrock function - and other integer decision problems - the tuning of
+ML models requires a variety of inputs, like in the example below.
 
 ```python
 from sklearn.cluster import DBSCAN
@@ -78,12 +96,23 @@ params = {
 }
 ```
 
+## 3. Optimization
+
+Use `study.optimize()` to start optimization with given settings.
+
+Internally, the method will need to store and transform the user inputs for rust-gmab,
+and then create and execute the set number of algorithm instances. Finally, it will also
+collect the results in a storage.
 
 ```python
-from gmab import Gmab
-
+study.optimize(objective, params, n_trials=5, n_simulations=10000, popsize=100, ...)
 ```
+
+## 4. Access the results (TBD.)
+
+Use `study.best_trial()` to output the best result that has been returned.
+
 ```python
-from gmab import Gmab
+result = study.best_trial()
 
 ```


### PR DESCRIPTION
As shortly discussed, this README outlines a vision for the interface of pygmab that will be implemented in future PRs. 

I've already got some ideas how to simply implement the examples for an MVP using mostly python, and with modifications to the rust code only when absolutely required. The mapping could lead to some additioal overhead, it is required for usability and any non-integer decision variables.