### PR TITLE
Enable seeding pygmab

### DIFF
--- a/pygmab/python/gmab/study/study.py
+++ b/pygmab/python/gmab/study/study.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
 
+import numpy as np
+
 from gmab import logging
 from gmab.gmab import Gmab
 
@@ -17,7 +19,9 @@ class Study:
 
     """
 
-    def __init__(self) -> None:
+    def __init__(self, seed: int | None) -> None:
+        self.seed: int | None = seed
+        self._rng: np.random.Generator = np.random.default_rng(self.seed)
         self._best_trial: dict | None = None
 
     @property
@@ -60,6 +64,20 @@ class Study:
         _logger.info("completed")
 
 
-def create_study() -> Study:
-    """Create a new :class:`~gmab.study.Study`."""
-    return Study()
+def create_study(seed: int | None = None) -> Study:
+    """
+    Create a new :class:`~gmab.study.Study`.
+
+    Args:
+        seed (int, optional):
+            The seed for the random number generator. Ensures reproducibility of random
+            algorithm progression if provided. If None (default), the system's entropy
+            or time is used to initialize the random generator.
+
+    Returns:
+        Study: A new instance of the :class:`~gmab.study.Study`.
+
+    """
+    if seed is None:
+        _logger.warning("Seed not provided. Results will not be reproducible.")
+    return Study(seed)

--- a/pygmab/python/gmab/study/study.py
+++ b/pygmab/python/gmab/study/study.py
@@ -59,8 +59,9 @@ class Study:
                 The number of simulations per trial. A trial will continue until the
                 number of elapsed simulations reaches `n_simulations`.
         """
-        # ToDo: Propagate the seed to rust-gmab, as soon as possible, like:
-        # gmab = Gmab(seed, func, bounds)
+        # ToDo: Propagate seed to Rust (32 or 64 bit?)
+        # algo_seed = self._rng.integers(0, 2**64)
+        # gmab = Gmab(algo_seed, func, bounds)
         gmab = Gmab(func, bounds)
         self._best_trial = gmab.optimize(n_simulations)
         _logger.info("completed")

--- a/pygmab/python/gmab/study/study.py
+++ b/pygmab/python/gmab/study/study.py
@@ -59,6 +59,8 @@ class Study:
                 The number of simulations per trial. A trial will continue until the
                 number of elapsed simulations reaches `n_simulations`.
         """
+        # ToDo: Propagate the seed to rust-gmab, as soon as possible, like:
+        # gmab = Gmab(seed, func, bounds)
         gmab = Gmab(func, bounds)
         self._best_trial = gmab.optimize(n_simulations)
         _logger.info("completed")

--- a/pygmab/tests/_functions/rosenbrock.py
+++ b/pygmab/tests/_functions/rosenbrock.py
@@ -1,0 +1,12 @@
+BOUNDS_2D = [(-5, 10), (-5, 10)]
+RESULT_2D = [1, 1]
+
+
+def objective(number: list):
+    """Computes the value of the multidimensional rosenbrock function."""
+    return sum(
+        [
+            100 * (number[i + 1] - number[i] ** 2) ** 2 + (1 - number[i]) ** 2
+            for i in range(len(number) - 1)
+        ]
+    )

--- a/pygmab/tests/study_tests/test_reproduction.py
+++ b/pygmab/tests/study_tests/test_reproduction.py
@@ -1,0 +1,19 @@
+import gmab
+import pytest
+
+from tests._functions import rosenbrock
+
+
+@pytest.mark.parametrize(
+    "seed, objective, bounds",
+    [pytest.param(42, rosenbrock.objective, rosenbrock.BOUNDS_2D, id="base")],
+)
+def test_reproduction(seed, objective, bounds):
+    def execute_study(seed, objective, bounds):
+        study = gmab.create_study(seed)
+        study.optimize(objective, bounds, n_simulations=1000)
+        return study.best_trial
+
+    first_result = execute_study(seed, objective, bounds)
+    second_result = execute_study(seed, objective, bounds)
+    assert first_result == second_result

--- a/pygmab/tests/study_tests/test_reproduction.py
+++ b/pygmab/tests/study_tests/test_reproduction.py
@@ -1,19 +1,37 @@
 import gmab
+import numpy as np
 import pytest
 
-from tests._functions import rosenbrock
+from tests._functions import rosenbrock as rb
 
 
+def get_rng(number: list) -> float:
+    """This function is designed showcase how an objective function without
+    seeded rng will break the reproduction of gmab's results, even when the
+    algorithm itself is seeded and reproducable"""
+    rng = np.random.default_rng(number[0])
+    return rng.uniform(low=number[1], high=number[1] + 100_000)
+
+
+# ToDo: Improve the test cases as soon as Rust-gmab is seeded.
 @pytest.mark.parametrize(
-    "seed, objective, bounds",
-    [pytest.param(42, rosenbrock.objective, rosenbrock.BOUNDS_2D, id="base")],
+    "seed, objective, bounds, expect_reproduction",
+    [
+        pytest.param(42, rb.objective, rb.BOUNDS_2D, True, id="deterministic"),
+        pytest.param(42, get_rng, [(42, 43), (0, 100_000)], True, id="fixed_rng"),
+        pytest.param(None, get_rng, [(0, 43), (0, 100_000)], False, id="unfixed_rng"),
+    ],
 )
-def test_reproduction(seed, objective, bounds):
+def test_reproduction(seed, objective, bounds, expect_reproduction):
     def execute_study(seed, objective, bounds):
         study = gmab.create_study(seed)
-        study.optimize(objective, bounds, n_simulations=1000)
+        study.optimize(objective, bounds, n_simulations=100)
         return study.best_trial
 
     first_result = execute_study(seed, objective, bounds)
     second_result = execute_study(seed, objective, bounds)
-    assert first_result == second_result
+
+    if expect_reproduction:
+        assert first_result == second_result
+    else:
+        assert first_result != second_result

--- a/pygmab/tests/study_tests/test_study.py
+++ b/pygmab/tests/study_tests/test_study.py
@@ -1,5 +1,5 @@
+import gmab
 import pytest
-from gmab import Study, create_study
 from pytest import LogCaptureFixture
 
 from tests._functions import rosenbrock
@@ -13,8 +13,8 @@ from tests._functions import rosenbrock
     ],
 )
 def test_create_study(seed, expected_warning, caplog: LogCaptureFixture):
-    study = create_study(seed)
-    assert isinstance(study, Study)
+    study = gmab.create_study(seed)
+    assert isinstance(study, gmab.Study)
     assert expected_warning in caplog.text
 
 
@@ -32,7 +32,7 @@ def test_create_study(seed, expected_warning, caplog: LogCaptureFixture):
     ],
 )
 def test_best_trial(seed, skip_optimize, expected_info, caplog: LogCaptureFixture):
-    study = create_study(seed)
+    study = gmab.create_study(seed)
 
     if not skip_optimize:
         n_simulations = 10_000

--- a/pygmab/tests/study_tests/test_study.py
+++ b/pygmab/tests/study_tests/test_study.py
@@ -2,14 +2,7 @@ import pytest
 from gmab import Study, create_study
 from pytest import LogCaptureFixture
 
-
-def rosenbrock_function(number: list):
-    return sum(
-        [
-            100 * (number[i + 1] - number[i] ** 2) ** 2 + (1 - number[i]) ** 2
-            for i in range(len(number) - 1)
-        ]
-    )
+from tests._functions import rosenbrock
 
 
 @pytest.mark.parametrize(
@@ -42,10 +35,9 @@ def test_best_trial(seed, skip_optimize, expected_info, caplog: LogCaptureFixtur
     study = create_study(seed)
 
     if not skip_optimize:
-        bounds = [(-5, 10), (-5, 10)]
         n_simulations = 10_000
-        study.optimize(rosenbrock_function, bounds, n_simulations)
+        study.optimize(rosenbrock.objective, rosenbrock.BOUNDS_2D, n_simulations)
         assert expected_info in caplog.text
 
     result = study.best_trial
-    assert result == [1, 1]
+    assert result == rosenbrock.RESULT_2D

--- a/pygmab/tests/study_tests/test_study.py
+++ b/pygmab/tests/study_tests/test_study.py
@@ -1,5 +1,5 @@
-import gmab
 import pytest
+from gmab import Study, create_study
 from pytest import LogCaptureFixture
 
 
@@ -12,17 +12,40 @@ def rosenbrock_function(number: list):
     )
 
 
-def test_best_trial(caplog: LogCaptureFixture):
-    study = gmab.create_study()
+@pytest.mark.parametrize(
+    "seed, expected_warning",
+    [
+        pytest.param(42, "", id="base"),
+        pytest.param(None, "Seed not provided", id="unseeded"),
+    ],
+)
+def test_create_study(seed, expected_warning, caplog: LogCaptureFixture):
+    study = create_study(seed)
+    assert isinstance(study, Study)
+    assert expected_warning in caplog.text
 
-    # best_trial requires running study.optimize()
-    with pytest.raises(RuntimeError):
-        result = study.best_trial
 
-    bounds = [(-5, 10), (-5, 10)]
-    n_simulations = 10_000
-    study.optimize(rosenbrock_function, bounds, n_simulations)
-    assert "completed" in caplog.text  # integrates logging
+@pytest.mark.parametrize(
+    "seed, skip_optimize, expected_info",
+    [
+        pytest.param(42, False, "completed", id="base"),
+        pytest.param(
+            42,
+            True,
+            "",
+            marks=pytest.mark.xfail(raises=RuntimeError),
+            id="skip_optimization",
+        ),
+    ],
+)
+def test_best_trial(seed, skip_optimize, expected_info, caplog: LogCaptureFixture):
+    study = create_study(seed)
+
+    if not skip_optimize:
+        bounds = [(-5, 10), (-5, 10)]
+        n_simulations = 10_000
+        study.optimize(rosenbrock_function, bounds, n_simulations)
+        assert expected_info in caplog.text
 
     result = study.best_trial
-    assert result == [1, 1]  # returns expected result
+    assert result == [1, 1]


### PR DESCRIPTION
The PR adds seeding to the Study module in pygmab.
It also improves the unittests for the module.

## Changes: 

- Study are now created with an optional `seed`.
- As results are not reproducible without a seed, a warning is logged if `seed=None`.
- Optimization is reproducible accross runs*

*for identical algorithm configuration, and unless the objective function introduces additional randomness that affects the algorithm.


## Why is this a draft PR? 

- This PR requires a solve for Issue [#19 Enable seeding for rust-gmab](https://github.com/E-MAB/GMAB/issues/19)
- Better testing needed to determine under which conditions Optimization is reproducible accross runs (see above)
- We might want to add a disclaimer in the README similar to section 12.2 on page 61 of the [documentation for IRace](https://cran.r-project.org/web/packages/irace/vignettes/irace-package.pdf).