### PR TITLE
Bugfix: Inconsistent Versioning

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -138,76 +138,76 @@ jobs:
   #            pip install gmab --find-links dist --force-reinstall
   #            pytest
 
-  # windows:
-  #   runs-on: ${{ matrix.platform.runner }}
-  #   strategy:
-  #     matrix:
-  #       platform:
-  #         - runner: windows-latest
-  #           target: x64
-  #         #- runner: windows-latest
-  #         #  target: x86
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: 3.x
-  #         architecture: ${{ matrix.platform.target }}
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.platform.target }}
-  #         args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
-  #         sccache: "true"
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-windows-${{ matrix.platform.target }}
-  #         path: dist
-  #     - name: pytest
-  #       if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
-  #       shell: bash
-  #       run: |
-  #         set -e
-  #         python3 -m venv .venv
-  #         source .venv/Scripts/activate
-  #         pip install gmab --find-links dist --force-reinstall
-  #         pip install pytest
-  #         pytest
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+          #- runner: windows-latest
+          #  target: x86
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          architecture: ${{ matrix.platform.target }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
+          sccache: "true"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}
+          path: dist
+      - name: pytest
+        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
+        shell: bash
+        run: |
+          set -e
+          python3 -m venv .venv
+          source .venv/Scripts/activate
+          pip install gmab --find-links dist --force-reinstall
+          pip install pytest
+          pytest
 
-  # macos:
-  #   runs-on: ${{ matrix.platform.runner }}
-  #   strategy:
-  #     matrix:
-  #       platform:
-  #         - runner: macos-13
-  #           target: x86_64
-  #         - runner: macos-14
-  #           target: aarch64
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: 3.x
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.platform.target }}
-  #         args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
-  #         sccache: "true"
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-macos-${{ matrix.platform.target }}
-  #         path: dist
-  #     - name: pytest
-  #       run: |
-  #         set -e
-  #         python3 -m venv .venv
-  #         source .venv/bin/activate
-  #         pip install gmab --find-links dist --force-reinstall
-  #         pip install pytest
-  #         pytest
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-13
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
+          sccache: "true"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: dist
+      - name: pytest
+        run: |
+          set -e
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install gmab --find-links dist --force-reinstall
+          pip install pytest
+          pytest
 
 #  sdist:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
+          sccache: "true"
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
-          sccache: "true"
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,6 +37,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+
+      - name: Check Cargo.toml
+        run: ls -l pygmab/Cargo.toml
+      - name: Verify Cargo installation
+        run: cargo --version
+
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,11 +38,8 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Check Cargo.toml
-        run: ls -l pygmab/Cargo.toml
-      - name: Verify Cargo installation
-        run: cargo --version
-
+      - name: Debug Cargo metadata
+        run: cargo metadata --format-version 1
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: dist
+          overwrite: "true"
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
         shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,7 +41,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
+          args: --release --out dist --find-interpreter --manifest-path .pygmab/Cargo.toml
           sccache: "true"
           manylinux: auto
       - name: Upload wheels
@@ -136,76 +136,76 @@ jobs:
   #            pip install gmab --find-links dist --force-reinstall
   #            pytest
 
-  windows:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-latest
-            target: x64
-          #- runner: windows-latest
-          #  target: x86
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-          architecture: ${{ matrix.platform.target }}
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
-          sccache: "true"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}
-          path: dist
-      - name: pytest
-        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
-        shell: bash
-        run: |
-          set -e
-          python3 -m venv .venv
-          source .venv/Scripts/activate
-          pip install gmab --find-links dist --force-reinstall
-          pip install pytest
-          pytest
+  # windows:
+  #   runs-on: ${{ matrix.platform.runner }}
+  #   strategy:
+  #     matrix:
+  #       platform:
+  #         - runner: windows-latest
+  #           target: x64
+  #         #- runner: windows-latest
+  #         #  target: x86
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: 3.x
+  #         architecture: ${{ matrix.platform.target }}
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.platform.target }}
+  #         args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
+  #         sccache: "true"
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-windows-${{ matrix.platform.target }}
+  #         path: dist
+  #     - name: pytest
+  #       if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
+  #       shell: bash
+  #       run: |
+  #         set -e
+  #         python3 -m venv .venv
+  #         source .venv/Scripts/activate
+  #         pip install gmab --find-links dist --force-reinstall
+  #         pip install pytest
+  #         pytest
 
-  macos:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: macos-13
-            target: x86_64
-          - runner: macos-14
-            target: aarch64
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
-          sccache: "true"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-${{ matrix.platform.target }}
-          path: dist
-      - name: pytest
-        run: |
-          set -e
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install gmab --find-links dist --force-reinstall
-          pip install pytest
-          pytest
+  # macos:
+  #   runs-on: ${{ matrix.platform.runner }}
+  #   strategy:
+  #     matrix:
+  #       platform:
+  #         - runner: macos-13
+  #           target: x86_64
+  #         - runner: macos-14
+  #           target: aarch64
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: 3.x
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.platform.target }}
+  #         args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
+  #         sccache: "true"
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-macos-${{ matrix.platform.target }}
+  #         path: dist
+  #     - name: pytest
+  #       run: |
+  #         set -e
+  #         python3 -m venv .venv
+  #         source .venv/bin/activate
+  #         pip install gmab --find-links dist --force-reinstall
+  #         pip install pytest
+  #         pytest
 
 #  sdist:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: dist
-          overwrite: "true"
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
         shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,7 +41,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path .pygmab/Cargo.toml
+          args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml
           sccache: "true"
           manylinux: auto
       - name: Upload wheels

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,12 +37,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-
-      - name: Debug Cargo metadata
-        run: cargo metadata --format-version 1
-
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        env:
+          CARGO_TARGET_DIR: target
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path pygmab/Cargo.toml

--- a/gmab/Cargo.toml
+++ b/gmab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gmab"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pygmab/Cargo.toml
+++ b/pygmab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pygmab"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pygmab/python/gmab/__init__.py
+++ b/pygmab/python/gmab/__init__.py
@@ -1,8 +1,10 @@
 from gmab import logging
+from gmab.gmab import Gmab
 from gmab.search import GmabSearchCV
 from gmab.study import Study, create_study
 
 __all__ = [
+    "Gmab",
     "GmabSearchCV",
     "logging",
     "Study",

--- a/pygmab/python/gmab/__init__.py
+++ b/pygmab/python/gmab/__init__.py
@@ -1,10 +1,8 @@
 from gmab import logging
-from gmab.gmab import Gmab
 from gmab.search import GmabSearchCV
 from gmab.study import Study, create_study
 
 __all__ = [
-    "Gmab",
     "GmabSearchCV",
     "logging",
     "Study",


### PR DESCRIPTION
## Changes made:
* Fixes an issue that leads to failed pipelines due to inconsistent versioning of gmab (see below)
* Minor fix that removes a warning for Cargo environment in the linux pipeline. 

## What was the issue?
The pipeline somehow expected wheels for gmab v0.1.3, while cargo/maturin compiled v0.1.0.

Tests no longer fail after manually adjusting the pyproject.toml. I've also adjusted the pygmab version accordingly.

I'm still a bit confused, why the pipeline did not fail for the past PR that introduced this error - let's discuss how we can avoid this going forward.