### PR TITLE
30 enable reproduction of results with seeding rust gmab

### DIFF
--- a/gmab/examples/inventory.rs
+++ b/gmab/examples/inventory.rs
@@ -6,7 +6,7 @@ use gmab::gmab::Gmab;
 
 fn random_poisson(lambda: f64) -> i32 {
     let poi = Poisson::new(lambda).unwrap();
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     poi.sample(&mut rng) as i32
 }
 

--- a/gmab/examples/inventory.rs
+++ b/gmab/examples/inventory.rs
@@ -1061,7 +1061,7 @@ fn main() {
     for i in 0..num_runs {
         let start_time = Instant::now(); // Record the start time
         let bounds = vec![(1, 100), (1, 100)]; // Set the bounds for the problem
-        let mut genetic_multi_armed_bandit = Gmab::new(inventory, bounds);
+        let mut genetic_multi_armed_bandit = Gmab::new(inventory, bounds, None);
         let result = genetic_multi_armed_bandit.optimize(10000);
 
         let elapsed_time = start_time.elapsed().as_secs_f64(); // Record the elapsed time

--- a/gmab/src/genetic.rs
+++ b/gmab/src/genetic.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
-use rand::Rng;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use rand_distr::{Distribution, Normal};
 
 use crate::arm::{Arm, OptimizationFn};
@@ -39,9 +40,9 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
         }
     }
 
-    pub(crate) fn generate_new_population(&self) -> Vec<Arm> {
+    pub(crate) fn generate_new_population(&self, seed: u64) -> Vec<Arm> {
         let mut individuals: Vec<Arm> = Vec::new();
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(seed);
 
         while individuals.len() < self.population_size {
             let candidate_solution: Vec<i32> = (0..self.dimension)
@@ -57,10 +58,10 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
         individuals
     }
 
-    pub(crate) fn crossover(&self, population: &[Arm]) -> Vec<Arm> {
+    pub(crate) fn crossover(&self, seed: u64, population: &[Arm]) -> Vec<Arm> {
         let mut crossover_pop: Vec<Arm> = Vec::new();
         let population_size = self.population_size;
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(seed);
 
         for i in (0..population_size).step_by(2) {
             if rand::random::<f64>() < self.crossover_rate {
@@ -99,10 +100,10 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
         crossover_pop
     }
 
-    pub(crate) fn mutate(&self, population: &[Arm]) -> Vec<Arm> {
+    pub(crate) fn mutate(&self, seed: u64, population: &[Arm]) -> Vec<Arm> {
         let mut mutated_population = Vec::new();
         let mut seen = HashSet::new();
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(seed);
 
         for individual in population.iter() {
             // Clone the action vector
@@ -173,7 +174,7 @@ mod tests {
 
         let initial_population = vec![Arm::new(&vec![1, 1]), Arm::new(&vec![2, 2])];
 
-        let mutated_population = ga.mutate(&initial_population);
+        let mutated_population = ga.mutate(42, &initial_population);
 
         // Assuming the mutation is deterministic and in the expected bounds, you'd check like this:
         for (i, individual) in mutated_population.iter().enumerate() {
@@ -207,7 +208,7 @@ mod tests {
             Arm::new(&vec![9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
         ];
 
-        let crossover_population = ga.crossover(&initial_population);
+        let crossover_population = ga.crossover(42, &initial_population);
 
         // Since the crossover rate is 100%, the two individuals should not be identical to the original individuals
         assert_ne!(

--- a/gmab/src/genetic.rs
+++ b/gmab/src/genetic.rs
@@ -28,11 +28,11 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
         dimension: usize,
         lower_bound: Vec<i32>,
         upper_bound: Vec<i32>,
-        state: Option<u64>,
+        seed: Option<u64>,
     ) -> Self {
-        // Try to set a state for rng, or fall back to system entropy
-        let state = state.unwrap_or_else(|| rand::rng().next_u64());
-        let rng = SeedableRng::seed_from_u64(state);
+        // Try to set a seed for rng, or fall back to system entropy
+        let seed = seed.unwrap_or_else(|| rand::rng().next_u64());
+        let rng = SeedableRng::seed_from_u64(seed);
 
         Self {
             rng,

--- a/gmab/src/genetic.rs
+++ b/gmab/src/genetic.rs
@@ -49,7 +49,7 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
 
     pub(crate) fn generate_new_population(&mut self) -> Vec<Arm> {
         let mut individuals: Vec<Arm> = Vec::new();
-        let mut rng = StdRng::seed_from_u64(self.rng.next_u64());
+        let mut rng: StdRng = SeedableRng::seed_from_u64(self.rng.next_u64());
 
         while individuals.len() < self.population_size {
             let candidate_solution: Vec<i32> = (0..self.dimension)
@@ -68,10 +68,10 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
     pub(crate) fn crossover(&mut self, population: &[Arm]) -> Vec<Arm> {
         let mut crossover_pop: Vec<Arm> = Vec::new();
         let population_size = self.population_size;
-        let mut rng = StdRng::seed_from_u64(self.rng.next_u64());
+        let mut rng: StdRng = SeedableRng::seed_from_u64(self.rng.next_u64());
 
         for i in (0..population_size).step_by(2) {
-            if rand::random::<f64>() < self.crossover_rate {
+            if rng.random::<f64>() < self.crossover_rate {
                 // Crossover
                 let max_dim_index = self.dimension - 1;
                 let swap_rv = rng.random_range(1..=max_dim_index);
@@ -233,8 +233,10 @@ mod tests {
 
     #[test]
     fn test_reproduction_with_seeding() {
-        let seed = 42;
+        // This test verifies the seeding in this module by testing if the same results are
+        // produced with the same seed, or different results are produced with another seed.
 
+        let seed = 42;
         let mut ga = GeneticAlgorithm::new(
             mock_opti_function,
             10,

--- a/gmab/src/genetic.rs
+++ b/gmab/src/genetic.rs
@@ -230,4 +230,66 @@ mod tests {
             initial_population[1].get_action_vector()
         );
     }
+
+    #[test]
+    fn test_reproduction_with_seeding() {
+        let seed = 42;
+
+        let mut ga = GeneticAlgorithm::new(
+            mock_opti_function,
+            10,
+            0.1,
+            0.9,
+            0.5,
+            2,
+            vec![0, 0],
+            vec![10, 10],
+            Some(seed),
+        );
+
+        let mut same_ga = GeneticAlgorithm::new(
+            mock_opti_function,
+            10,
+            0.1,
+            0.9,
+            0.5,
+            2,
+            vec![0, 0],
+            vec![10, 10],
+            Some(seed),
+        );
+
+        let mut diff_ga = GeneticAlgorithm::new(
+            mock_opti_function,
+            10,
+            0.1,
+            0.9,
+            0.5,
+            2,
+            vec![0, 0],
+            vec![10, 10],
+            Some(seed + 1),
+        );
+
+        // Verify generation of new populations with seeding
+        let mut ga_population = ga.generate_new_population();
+        let mut same_ga_population = same_ga.generate_new_population();
+        let mut diff_ga_population = diff_ga.generate_new_population();
+        assert_eq!(ga_population, same_ga_population);
+        assert_ne!(ga_population, diff_ga_population);
+
+        // Verify crossover with seeding
+        ga_population = ga.crossover(&ga_population);
+        same_ga_population = same_ga.crossover(&same_ga_population);
+        diff_ga_population = diff_ga.crossover(&diff_ga_population);
+        assert_eq!(ga_population, same_ga_population);
+        assert_ne!(ga_population, diff_ga_population);
+
+        // Verify mutation with seeding
+        ga_population = ga.mutate(&ga_population);
+        same_ga_population = same_ga.mutate(&same_ga_population);
+        diff_ga_population = diff_ga.mutate(&diff_ga_population);
+        assert_eq!(ga_population, same_ga_population);
+        assert_ne!(ga_population, diff_ga_population);
+    }
 }

--- a/gmab/src/gmab.rs
+++ b/gmab/src/gmab.rs
@@ -2,7 +2,6 @@ use crate::arm::{Arm, OptimizationFn};
 use crate::genetic::GeneticAlgorithm;
 use crate::sorted_multi_map::{FloatKey, SortedMultiMap};
 use rand::prelude::SliceRandom;
-use rand::RngCore;
 use std::collections::HashMap;
 
 pub struct Gmab<F: OptimizationFn> {
@@ -23,7 +22,7 @@ impl<F: OptimizationFn> Gmab<F> {
         }
     }
 
-    pub fn new(opti_function: F, bounds: Vec<(i32, i32)>, seed: Option<u64>) -> Gmab<F> {
+    pub fn new(opti_function: F, bounds: Vec<(i32, i32)>, state: Option<u64>) -> Gmab<F> {
         let dimension = bounds.len();
         let lower_bound = bounds.iter().map(|&(low, _)| low).collect::<Vec<i32>>();
         let upper_bound = bounds.iter().map(|&(_, high)| high).collect::<Vec<i32>>();
@@ -43,7 +42,7 @@ impl<F: OptimizationFn> Gmab<F> {
             dimension,
             lower_bound,
             upper_bound,
-            seed,
+            state,
         )
     }
 
@@ -56,11 +55,8 @@ impl<F: OptimizationFn> Gmab<F> {
         dimension: usize,
         lower_bound: Vec<i32>,
         upper_bound: Vec<i32>,
-        seed: Option<u64>,
+        state: Option<u64>,
     ) -> Gmab<F> {
-        // ToDo: propagate rng instead of seed to disable global seed propagation
-        let seed = seed.unwrap_or_else(|| rand::rng().next_u64());
-
         // Raise an Exception if population_size > solution space
         let mut solution_size: usize = 1;
         let mut not_enough_solutions = true;
@@ -78,8 +74,7 @@ impl<F: OptimizationFn> Gmab<F> {
             );
         }
 
-        let genetic_algorithm = GeneticAlgorithm::new(
-            seed,
+        let mut genetic_algorithm = GeneticAlgorithm::new(
             opti_function,
             population_size,
             mutation_rate,
@@ -88,6 +83,7 @@ impl<F: OptimizationFn> Gmab<F> {
             dimension,
             lower_bound,
             upper_bound,
+            state,
         );
 
         let mut arm_memory: Vec<Arm> = Vec::new();

--- a/gmab/src/gmab.rs
+++ b/gmab/src/gmab.rs
@@ -87,7 +87,8 @@ impl<F: OptimizationFn> Gmab<F> {
         let mut lookup_table: HashMap<Vec<i32>, i32> = HashMap::new();
         let mut sample_average_tree: SortedMultiMap<FloatKey, i32> = SortedMultiMap::new();
 
-        let mut initial_population = genetic_algorithm.generate_new_population();
+        // ToDo: Seeding
+        let mut initial_population = genetic_algorithm.generate_new_population(42);
 
         for (index, individual) in initial_population.iter_mut().enumerate() {
             individual.pull(&genetic_algorithm.opti_function);
@@ -211,10 +212,12 @@ impl<F: OptimizationFn> Gmab<F> {
             // shuffle population
             population.shuffle(&mut rand::rng());
 
-            let crossover_pop = self.genetic_algorithm.crossover(&population);
+            // ToDo: seeding
+            let crossover_pop = self.genetic_algorithm.crossover(42, &population);
 
             // mutate automatically removes duplicates
-            let mutated_pop = self.genetic_algorithm.mutate(&crossover_pop);
+            // ToDo: seeding
+            let mutated_pop = self.genetic_algorithm.mutate(42, &crossover_pop);
 
             for individual in mutated_pop {
                 let arm_index = self.get_arm_index(&individual);

--- a/gmab/src/gmab.rs
+++ b/gmab/src/gmab.rs
@@ -22,7 +22,7 @@ impl<F: OptimizationFn> Gmab<F> {
         }
     }
 
-    pub fn new(opti_function: F, bounds: Vec<(i32, i32)>, state: Option<u64>) -> Gmab<F> {
+    pub fn new(opti_function: F, bounds: Vec<(i32, i32)>, seed: Option<u64>) -> Gmab<F> {
         let dimension = bounds.len();
         let lower_bound = bounds.iter().map(|&(low, _)| low).collect::<Vec<i32>>();
         let upper_bound = bounds.iter().map(|&(_, high)| high).collect::<Vec<i32>>();
@@ -42,7 +42,7 @@ impl<F: OptimizationFn> Gmab<F> {
             dimension,
             lower_bound,
             upper_bound,
-            state,
+            seed,
         )
     }
 
@@ -55,7 +55,7 @@ impl<F: OptimizationFn> Gmab<F> {
         dimension: usize,
         lower_bound: Vec<i32>,
         upper_bound: Vec<i32>,
-        state: Option<u64>,
+        seed: Option<u64>,
     ) -> Gmab<F> {
         // Raise an Exception if population_size > solution space
         let mut solution_size: usize = 1;
@@ -83,7 +83,7 @@ impl<F: OptimizationFn> Gmab<F> {
             dimension,
             lower_bound,
             upper_bound,
-            state,
+            seed,
         );
 
         let mut arm_memory: Vec<Arm> = Vec::new();

--- a/pygmab/src/lib.rs
+++ b/pygmab/src/lib.rs
@@ -37,7 +37,7 @@ struct Gmab {
 #[pymethods]
 impl Gmab {
     #[new]
-    // ToDo: make seeding optional
+    #[pyo3(signature = (py_func, bounds, seed=None))]
     fn new(py_func: PyObject, bounds: Vec<(i32, i32)>, seed: Option<u64>) -> PyResult<Self> {
         let python_opti_fn = PythonOptimizationFn::new(py_func);
 

--- a/pygmab/src/lib.rs
+++ b/pygmab/src/lib.rs
@@ -37,10 +37,11 @@ struct Gmab {
 #[pymethods]
 impl Gmab {
     #[new]
-    fn new(py_func: PyObject, bounds: Vec<(i32, i32)>) -> PyResult<Self> {
+    // ToDo: make seeding optional
+    fn new(py_func: PyObject, bounds: Vec<(i32, i32)>, seed: Option<u64>) -> PyResult<Self> {
         let python_opti_fn = PythonOptimizationFn::new(py_func);
 
-        match panic::catch_unwind(|| RustGmab::new(python_opti_fn, bounds)) {
+        match panic::catch_unwind(|| RustGmab::new(python_opti_fn, bounds, seed)) {
             Ok(gmab) => Ok(Gmab { gmab }),
             Err(err) => {
                 let err_message = if let Some(msg) = err.downcast_ref::<&str>() {

--- a/pygmab/tests/gmab_rs_tests/test_rs_gmab.py
+++ b/pygmab/tests/gmab_rs_tests/test_rs_gmab.py
@@ -6,6 +6,15 @@ def function(number: list) -> float:
     return sum([i**2 for i in number])
 
 
+def rosenbrock_function(number: list):
+    return sum(
+        [
+            100 * (number[i + 1] - number[i] ** 2) ** 2 + (1 - number[i]) ** 2
+            for i in range(len(number) - 1)
+        ]
+    )
+
+
 def test_gmab_new():
     with pytest.raises(RuntimeError) as err:
         bounds = [(0, 1), (0, 1)]  # less than 20 combinations
@@ -16,16 +25,16 @@ def test_gmab_new():
 
 
 def test_gmab_seeding():
-    bounds = [(0, 100), (0, 100)]
-    budget = 1
+    bounds = [(0, 100), (0, 100)] * 5
+    budget = 100
     seed = 42
-    gmab = Gmab(function, bounds, seed)
+    gmab = Gmab(rosenbrock_function, bounds, seed)
     result = gmab.optimize(budget)
 
-    same_gmab = Gmab(function, bounds, seed)
+    same_gmab = Gmab(rosenbrock_function, bounds, seed)
     same_result = same_gmab.optimize(budget)
     assert result == same_result
 
-    different_gmab = Gmab(function, bounds, seed + 1)
+    different_gmab = Gmab(rosenbrock_function, bounds, seed + 1)
     different_result = different_gmab.optimize(budget)
     assert result != different_result

--- a/pygmab/tests/gmab_rs_tests/test_rs_gmab.py
+++ b/pygmab/tests/gmab_rs_tests/test_rs_gmab.py
@@ -13,3 +13,19 @@ def test_gmab_new():
 
     exp_msg = "population_size"
     assert exp_msg in str(err.value)
+
+
+def test_gmab_seeding():
+    bounds = [(0, 100), (0, 100)]
+    budget = 1
+    seed = 42
+    gmab = Gmab(function, bounds, seed)
+    result = gmab.optimize(budget)
+
+    same_gmab = Gmab(function, bounds, seed)
+    same_result = same_gmab.optimize(budget)
+    assert result == same_result
+
+    different_gmab = Gmab(function, bounds, seed + 1)
+    different_result = different_gmab.optimize(budget)
+    assert result != different_result


### PR DESCRIPTION
## Overview

* Adds an optional seed (or state) to `gmab/src/genetic.rs`. The seed defaults to system entropy if None.
* The seed is used to initialize a RNG for the genetic.rs module. 
* Using this RNG, a new RNG is created for each individual call to sample a new population, crossover, or mutation. Therefore, reproduction is possible, but the RNG of each operation is not globally coupled to the initial seed. Procedures like population generation, crossover or mutation are free to use different types of RNGs if required.
* The seed type is `u64`, similar to [seeding in polars](https://github.com/search?q=repo%3Apola-rs%2Fpolars%20seed&type=code)
* Modifies `gmab/scr/gmab.rs` and bindings in `pygmab/src/lib.rs` accordingly
* Adds a python unittest case to check if results can be reproduced
* Adds a rust unittest case to check if results can be reproduced

Rust docs: https://rust-random.github.io/book/guide-seeding.html