### PR TITLE
30 fix seeding rust gmab

### DIFF
--- a/gmab/src/genetic.rs
+++ b/gmab/src/genetic.rs
@@ -227,36 +227,29 @@ mod tests {
         // This test verifies the seeding in this module by testing if the same results are
         // produced with the same seed, or different results are produced with another seed.
 
-        let ga = GeneticAlgorithm::new(
-            mock_opti_function,
-            10,
-            0.1,
-            0.9,
-            0.5,
-            2,
-            vec![0, 0],
-            vec![10, 10],
-        );
+        fn generate_population(seed: u64) -> Vec<Arm> {
+            let ga = GeneticAlgorithm::new(
+                mock_opti_function,
+                10,
+                0.1,
+                0.9,
+                0.5,
+                2,
+                vec![0, 0],
+                vec![10, 10],
+            );
 
-        // Verify generation of new populations with seeding
-        let mut ga_population = ga.generate_new_population(SEED);
-        let mut same_ga_population = ga.generate_new_population(SEED);
-        let mut diff_ga_population = ga.generate_new_population(SEED + 1);
-        assert_eq!(ga_population, same_ga_population);
-        assert_ne!(ga_population, diff_ga_population);
+            let mut population = ga.generate_new_population(seed);
+            population = ga.crossover(seed, &population);
+            population = ga.mutate(seed, &population);
 
-        // Verify crossover with seeding
-        ga_population = ga.crossover(SEED, &ga_population);
-        same_ga_population = ga.crossover(SEED, &same_ga_population);
-        diff_ga_population = ga.crossover(SEED + 1, &diff_ga_population);
-        assert_eq!(ga_population, same_ga_population);
-        assert_ne!(ga_population, diff_ga_population);
+            return population;
+        }
 
-        // Verify mutation with seeding
-        ga_population = ga.mutate(SEED, &ga_population);
-        same_ga_population = ga.mutate(SEED, &same_ga_population);
-        diff_ga_population = ga.mutate(SEED + 1, &diff_ga_population);
-        assert_eq!(ga_population, same_ga_population);
-        assert_ne!(ga_population, diff_ga_population);
+        // The same seed should lead to the same population
+        assert_eq!(generate_population(SEED), generate_population(SEED));
+
+        // A different seed should not lead to the same population
+        assert_ne!(generate_population(SEED), generate_population(SEED + 1));
     }
 }

--- a/gmab/src/genetic.rs
+++ b/gmab/src/genetic.rs
@@ -224,9 +224,7 @@ mod tests {
 
     #[test]
     fn test_reproduction_with_seeding() {
-        // This test verifies the seeding in this module by testing if the same results are
-        // produced with the same seed, or different results are produced with another seed.
-
+        // Helper function that generates and modifies a population using a seed.
         fn generate_population(seed: u64) -> Vec<Arm> {
             let ga = GeneticAlgorithm::new(
                 mock_opti_function,

--- a/gmab/src/genetic.rs
+++ b/gmab/src/genetic.rs
@@ -1,13 +1,12 @@
 use std::collections::HashSet;
 
 use rand::rngs::StdRng;
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_distr::{Distribution, Normal};
 
 use crate::arm::{Arm, OptimizationFn};
 
 pub(crate) struct GeneticAlgorithm<F: OptimizationFn> {
-    rng: StdRng,
     mutation_rate: f64,
     crossover_rate: f64,
     mutation_span: f64,
@@ -28,14 +27,8 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
         dimension: usize,
         lower_bound: Vec<i32>,
         upper_bound: Vec<i32>,
-        seed: Option<u64>,
     ) -> Self {
-        // Try to set a seed for rng, or fall back to system entropy
-        let seed = seed.unwrap_or_else(|| rand::rng().next_u64());
-        let rng = SeedableRng::seed_from_u64(seed);
-
         Self {
-            rng,
             mutation_rate,
             crossover_rate,
             mutation_span,
@@ -47,9 +40,9 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
         }
     }
 
-    pub(crate) fn generate_new_population(&mut self) -> Vec<Arm> {
+    pub(crate) fn generate_new_population(&self, seed: u64) -> Vec<Arm> {
         let mut individuals: Vec<Arm> = Vec::new();
-        let mut rng: StdRng = SeedableRng::seed_from_u64(self.rng.next_u64());
+        let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
 
         while individuals.len() < self.population_size {
             let candidate_solution: Vec<i32> = (0..self.dimension)
@@ -65,10 +58,10 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
         individuals
     }
 
-    pub(crate) fn crossover(&mut self, population: &[Arm]) -> Vec<Arm> {
+    pub(crate) fn crossover(&self, seed: u64, population: &[Arm]) -> Vec<Arm> {
         let mut crossover_pop: Vec<Arm> = Vec::new();
         let population_size = self.population_size;
-        let mut rng: StdRng = SeedableRng::seed_from_u64(self.rng.next_u64());
+        let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
 
         for i in (0..population_size).step_by(2) {
             if rng.random::<f64>() < self.crossover_rate {
@@ -107,10 +100,10 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
         crossover_pop
     }
 
-    pub(crate) fn mutate(&mut self, population: &[Arm]) -> Vec<Arm> {
+    pub(crate) fn mutate(&self, seed: u64, population: &[Arm]) -> Vec<Arm> {
         let mut mutated_population = Vec::new();
         let mut seen = HashSet::new();
-        let mut rng = StdRng::seed_from_u64(self.rng.next_u64());
+        let mut rng = StdRng::seed_from_u64(seed);
 
         for individual in population.iter() {
             // Clone the action vector
@@ -145,6 +138,7 @@ impl<F: OptimizationFn> GeneticAlgorithm<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    const SEED: u64 = 42;
 
     // Mock optimization function for testing
     fn mock_opti_function(_vec: &[i32]) -> f64 {
@@ -162,14 +156,13 @@ mod tests {
             2,
             vec![0, 0],
             vec![10, 10],
-            None,
         );
         assert_eq!(ga.population_size, 10);
     }
 
     #[test]
     fn test_mutate() {
-        let mut ga = GeneticAlgorithm::new(
+        let ga = GeneticAlgorithm::new(
             mock_opti_function,
             2,   // Two individuals in population
             1.0, // 100% mutation rate for demonstration
@@ -178,12 +171,11 @@ mod tests {
             2,
             vec![0, 0],
             vec![10, 10],
-            None,
         );
 
         let initial_population = vec![Arm::new(&vec![1, 1]), Arm::new(&vec![2, 2])];
 
-        let mutated_population = ga.mutate(&initial_population);
+        let mutated_population = ga.mutate(SEED, &initial_population);
 
         // Assuming the mutation is deterministic and in the expected bounds, you'd check like this:
         for (i, individual) in mutated_population.iter().enumerate() {
@@ -201,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_crossover() {
-        let mut ga = GeneticAlgorithm::new(
+        let ga = GeneticAlgorithm::new(
             mock_opti_function,
             2, // Two individuals for simplicity
             0.1,
@@ -210,7 +202,6 @@ mod tests {
             10, // higher dimension for demonstration so low probability of crossover leading to identical individuals
             vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             vec![10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
-            None,
         );
 
         let initial_population = vec![
@@ -218,7 +209,7 @@ mod tests {
             Arm::new(&vec![9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
         ];
 
-        let crossover_population = ga.crossover(&initial_population);
+        let crossover_population = ga.crossover(SEED, &initial_population);
 
         // Since the crossover rate is 100%, the two individuals should not be identical to the original individuals
         assert_ne!(
@@ -236,8 +227,7 @@ mod tests {
         // This test verifies the seeding in this module by testing if the same results are
         // produced with the same seed, or different results are produced with another seed.
 
-        let seed = 42;
-        let mut ga = GeneticAlgorithm::new(
+        let ga = GeneticAlgorithm::new(
             mock_opti_function,
             10,
             0.1,
@@ -246,51 +236,26 @@ mod tests {
             2,
             vec![0, 0],
             vec![10, 10],
-            Some(seed),
-        );
-
-        let mut same_ga = GeneticAlgorithm::new(
-            mock_opti_function,
-            10,
-            0.1,
-            0.9,
-            0.5,
-            2,
-            vec![0, 0],
-            vec![10, 10],
-            Some(seed),
-        );
-
-        let mut diff_ga = GeneticAlgorithm::new(
-            mock_opti_function,
-            10,
-            0.1,
-            0.9,
-            0.5,
-            2,
-            vec![0, 0],
-            vec![10, 10],
-            Some(seed + 1),
         );
 
         // Verify generation of new populations with seeding
-        let mut ga_population = ga.generate_new_population();
-        let mut same_ga_population = same_ga.generate_new_population();
-        let mut diff_ga_population = diff_ga.generate_new_population();
+        let mut ga_population = ga.generate_new_population(SEED);
+        let mut same_ga_population = ga.generate_new_population(SEED);
+        let mut diff_ga_population = ga.generate_new_population(SEED + 1);
         assert_eq!(ga_population, same_ga_population);
         assert_ne!(ga_population, diff_ga_population);
 
         // Verify crossover with seeding
-        ga_population = ga.crossover(&ga_population);
-        same_ga_population = same_ga.crossover(&same_ga_population);
-        diff_ga_population = diff_ga.crossover(&diff_ga_population);
+        ga_population = ga.crossover(SEED, &ga_population);
+        same_ga_population = ga.crossover(SEED, &same_ga_population);
+        diff_ga_population = ga.crossover(SEED + 1, &diff_ga_population);
         assert_eq!(ga_population, same_ga_population);
         assert_ne!(ga_population, diff_ga_population);
 
         // Verify mutation with seeding
-        ga_population = ga.mutate(&ga_population);
-        same_ga_population = same_ga.mutate(&same_ga_population);
-        diff_ga_population = diff_ga.mutate(&diff_ga_population);
+        ga_population = ga.mutate(SEED, &ga_population);
+        same_ga_population = ga.mutate(SEED, &same_ga_population);
+        diff_ga_population = ga.mutate(SEED + 1, &diff_ga_population);
         assert_eq!(ga_population, same_ga_population);
         assert_ne!(ga_population, diff_ga_population);
     }

--- a/gmab/src/gmab.rs
+++ b/gmab/src/gmab.rs
@@ -77,7 +77,7 @@ impl<F: OptimizationFn> Gmab<F> {
             );
         }
 
-        let mut genetic_algorithm = GeneticAlgorithm::new(
+        let genetic_algorithm = GeneticAlgorithm::new(
             opti_function,
             population_size,
             mutation_rate,
@@ -86,7 +86,6 @@ impl<F: OptimizationFn> Gmab<F> {
             dimension,
             lower_bound,
             upper_bound,
-            seed,
         );
 
         // Try to set a seed for rng, or fall back to system entropy
@@ -97,7 +96,8 @@ impl<F: OptimizationFn> Gmab<F> {
         let mut lookup_table: HashMap<Vec<i32>, i32> = HashMap::new();
         let mut sample_average_tree: SortedMultiMap<FloatKey, i32> = SortedMultiMap::new();
 
-        let mut initial_population = genetic_algorithm.generate_new_population();
+        let next_seed = rng.next_u64();
+        let mut initial_population = genetic_algorithm.generate_new_population(next_seed);
 
         for (index, individual) in initial_population.iter_mut().enumerate() {
             individual.pull(&genetic_algorithm.opti_function);
@@ -222,10 +222,12 @@ impl<F: OptimizationFn> Gmab<F> {
             // shuffle population
             population.shuffle(&mut self.rng);
 
-            let crossover_pop = self.genetic_algorithm.crossover(&population);
+            let next_seed = self.rng.next_u64();
+            let crossover_pop = self.genetic_algorithm.crossover(next_seed, &population);
 
             // mutate automatically removes duplicates
-            let mutated_pop = self.genetic_algorithm.mutate(&crossover_pop);
+            let next_seed = self.rng.next_u64();
+            let mutated_pop = self.genetic_algorithm.mutate(next_seed, &crossover_pop);
 
             for individual in mutated_pop {
                 let arm_index = self.get_arm_index(&individual);

--- a/gmab/src/gmab.rs
+++ b/gmab/src/gmab.rs
@@ -475,4 +475,27 @@ mod tests {
             Some(&0)
         );
     }
+
+    #[test]
+    fn test_reproduction_with_seeding() {
+        // Mock optimization function for testing
+        fn mock_opti_function(_vec: &[i32]) -> f64 {
+            0.0
+        }
+
+        // Helper function that generates and modifies a gmab result using a seed.
+        fn generate_result(seed: Option<u64>) -> Vec<i32> {
+            let bounds = vec![(1, 100), (1, 100)];
+            let mut genetic_multi_armed_bandit = Gmab::new(mock_opti_function, bounds, seed);
+            let result = genetic_multi_armed_bandit.optimize(100);
+            return result;
+        }
+
+        // The same seed should lead to the same result
+        let seed = 42;
+        assert_eq!(generate_result(Some(seed)), generate_result(Some(seed)));
+
+        // A different seed should not lead to the same population
+        assert_ne!(generate_result(Some(seed)), generate_result(Some(seed + 1)));
+    }
 }

--- a/pygmab/tests/gmab_rs_tests/test_rs_gmab.py
+++ b/pygmab/tests/gmab_rs_tests/test_rs_gmab.py
@@ -1,12 +1,12 @@
+from contextlib import nullcontext
+
 import pytest
 from gmab import Gmab
 
-
-def function(number: list) -> float:
-    return sum([i**2 for i in number])
+SEED = 42
 
 
-def rosenbrock_function(number: list):
+def rb_function(number: list):
     return sum(
         [
             100 * (number[i + 1] - number[i] ** 2) ** 2 + (1 - number[i]) ** 2
@@ -15,26 +15,23 @@ def rosenbrock_function(number: list):
     )
 
 
-def test_gmab_new():
-    with pytest.raises(RuntimeError) as err:
-        bounds = [(0, 1), (0, 1)]  # less than 20 combinations
-        _ = Gmab(function, bounds)
-
-    exp_msg = "population_size"
-    assert exp_msg in str(err.value)
-
-
-def test_gmab_seeding():
-    bounds = [(0, 100), (0, 100)] * 5
-    budget = 100
-    seed = 42
-    gmab = Gmab(rosenbrock_function, bounds, seed)
-    result = gmab.optimize(budget)
-
-    same_gmab = Gmab(rosenbrock_function, bounds, seed)
-    same_result = same_gmab.optimize(budget)
-    assert result == same_result
-
-    different_gmab = Gmab(rosenbrock_function, bounds, seed + 1)
-    different_result = different_gmab.optimize(budget)
-    assert result != different_result
+@pytest.mark.parametrize(
+    "bounds, budget, kwargs",
+    [
+        [[(0, 100), (0, 100)] * 5, 100, {}],
+        [[(0, 100), (0, 100)] * 5, 100, {"seed": SEED}],
+        [[(0, 100), (0, 100)] * 5, 100, {"seed": float(SEED), "exp": pytest.raises(TypeError)}],
+        [[(0, 1), (0, 1)], None, {"exp": pytest.raises(RuntimeError)}],
+    ],
+    ids=[
+        "success",
+        "success_with_seed",
+        "fail_seed_value",
+        "fail_population_size",
+    ],
+)
+def test_gmab(bounds, budget, kwargs):
+    expectation = kwargs.pop("exp", nullcontext())
+    with expectation:
+        gmab = Gmab(rb_function, bounds, **kwargs)
+        _ = gmab.optimize(budget)


### PR DESCRIPTION
Summary: 

* I've identified an issue in the unittest for seeding gmab.rs which allowed an unseeded rng. Specifically, the rng for shuffling the population in gmab.rs was still not seeded, and my unittest did not (regularly) fail because the simulation budget was too low to progress to that point. 

Changes made: 

* Added seeding to shuffle population.
* This required some changes to the seeding as a whole, as seeding is needed in gmab.rs. I've therefore moved the rng that controls the seed for each individual process (=generate a new population, call of mutation function, etc) to gmab.rs accordingly.
* This enabled me to essentially "revert" the changes made to the genetic.rs module in #48, except the seeded rngs.
* Cleaned up the unittests

This PR closes Issue #30 